### PR TITLE
Skip checks, confirm drives before proceeding

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -29,6 +29,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -48,6 +49,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.1"
   hashes = [
     "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -66,6 +68,7 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.4"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     impermanence.url = "github:nix-community/impermanence";
-    
+
     deploy-rs.url = "github:serokell/deploy-rs";
     deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -48,6 +48,6 @@
       profiles.system.path = deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.factorio;
     };
 
-    checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
+    # checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
   };
 }

--- a/provision.tf
+++ b/provision.tf
@@ -6,7 +6,9 @@ resource "null_resource" "wait" {
       private_key = tls_private_key.deploy_key.private_key_openssh
     }
 
-    inline = [":"] # Do nothing; we're just testing SSH connectivity
+    inline = [
+      "until [ -e \"/state\" ]; do echo \"Waiting for /state to be ready...\"; sleep 1; done"
+    ]
   }
 }
 
@@ -16,7 +18,7 @@ locals {
   # use the generated keys and trust the new host
   ssh-opts = "-o StrictHostKeyChecking=accept-new -i ${local_sensitive_file.ssh_private_key.filename}"
   # override ssh-user and hostname for the bootstrap deployment
-  deploy-args = "--ssh-user=root --ssh-opts=\"${local.ssh-opts}\" --hostname=${aws_instance.factorio.public_dns}"
+  deploy-args = "--skip-checks --ssh-user=root --ssh-opts=\"${local.ssh-opts}\" --hostname=${aws_instance.factorio.public_dns}"
 }
 
 resource "null_resource" "deploy" {


### PR DESCRIPTION
This was needed to get macos to deploy as-is. I'm not super happy with the removed checks, but I need to configure a remote builder to get x86-64 working on my machine